### PR TITLE
Document external media requirements and remove binary assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+_site/
+.sass-cache/
+.jekyll-cache/
+.bundle/
+.DS_Store

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gem 'jekyll', '~> 4.3'
+
+group :development do
+  gem 'webrick', '~> 1.7'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,162 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
+    base64 (0.3.0)
+    bigdecimal (3.2.3)
+    colorator (1.1.0)
+    concurrent-ruby (1.3.5)
+    csv (3.3.5)
+    em-websocket (0.5.3)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0)
+    eventmachine (1.2.7)
+    ffi (1.17.2)
+    ffi (1.17.2-aarch64-linux-gnu)
+    ffi (1.17.2-aarch64-linux-musl)
+    ffi (1.17.2-arm-linux-gnu)
+    ffi (1.17.2-arm-linux-musl)
+    ffi (1.17.2-arm64-darwin)
+    ffi (1.17.2-x86-linux-gnu)
+    ffi (1.17.2-x86-linux-musl)
+    ffi (1.17.2-x86_64-darwin)
+    ffi (1.17.2-x86_64-linux-gnu)
+    ffi (1.17.2-x86_64-linux-musl)
+    forwardable-extended (2.6.0)
+    google-protobuf (4.32.1)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.1-aarch64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.1-aarch64-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.1-arm64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.1-x86-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.1-x86-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.1-x86_64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.1-x86_64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.32.1-x86_64-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    http_parser.rb (0.8.0)
+    i18n (1.14.7)
+      concurrent-ruby (~> 1.0)
+    jekyll (4.4.1)
+      addressable (~> 2.4)
+      base64 (~> 0.2)
+      colorator (~> 1.0)
+      csv (~> 3.0)
+      em-websocket (~> 0.5)
+      i18n (~> 1.0)
+      jekyll-sass-converter (>= 2.0, < 4.0)
+      jekyll-watch (~> 2.0)
+      json (~> 2.6)
+      kramdown (~> 2.3, >= 2.3.1)
+      kramdown-parser-gfm (~> 1.0)
+      liquid (~> 4.0)
+      mercenary (~> 0.3, >= 0.3.6)
+      pathutil (~> 0.9)
+      rouge (>= 3.0, < 5.0)
+      safe_yaml (~> 1.0)
+      terminal-table (>= 1.8, < 4.0)
+      webrick (~> 1.7)
+    jekyll-sass-converter (3.1.0)
+      sass-embedded (~> 1.75)
+    jekyll-watch (2.2.1)
+      listen (~> 3.0)
+    json (2.15.0)
+    kramdown (2.5.1)
+      rexml (>= 3.3.9)
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    liquid (4.0.4)
+    listen (3.9.0)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    mercenary (0.4.0)
+    pathutil (0.16.2)
+      forwardable-extended (~> 2.6)
+    public_suffix (6.0.2)
+    rake (13.3.0)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
+      ffi (~> 1.0)
+    rexml (3.4.4)
+    rouge (4.6.1)
+    safe_yaml (1.0.5)
+    sass-embedded (1.93.2)
+      google-protobuf (~> 4.31)
+      rake (>= 13)
+    sass-embedded (1.93.2-aarch64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-aarch64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-aarch64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-arm-linux-androideabi)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-arm-linux-gnueabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-arm-linux-musleabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-arm64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-riscv64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-riscv64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-riscv64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-x86_64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-x86_64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-x86_64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.93.2-x86_64-linux-musl)
+      google-protobuf (~> 4.31)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
+    unicode-display_width (2.6.0)
+    webrick (1.9.1)
+
+PLATFORMS
+  aarch64-linux-android
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-androideabi
+  arm-linux-gnu
+  arm-linux-gnueabihf
+  arm-linux-musl
+  arm-linux-musleabihf
+  arm64-darwin
+  riscv64-linux-android
+  riscv64-linux-gnu
+  riscv64-linux-musl
+  ruby
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
+  x86_64-linux-android
+  x86_64-linux-gnu
+  x86_64-linux-musl
+
+DEPENDENCIES
+  jekyll (~> 4.3)
+  webrick (~> 1.7)
+
+BUNDLED WITH
+   2.6.7

--- a/README.md
+++ b/README.md
@@ -1,1 +1,47 @@
-Migration of existing site at stabatmater.info (in Wordpress) to a Jekyll based site in Github Pages
+# Stabat Mater Jekyll Migration
+
+This repository houses the migration of [stabatmater.info](https://stabatmater.info) from WordPress to a modular, data-driven Jekyll site that can be deployed to GitHub Pages.
+
+## Migration plan
+
+1. **Structuur opzetten** – Maak de standaard Jekyll-structuur met `_layouts`, `_includes`, `_data` en `assets/`. Definieer een `default`-layout die de hoofdomlijsting (html/head/body) bevat.
+2. **Navigatie modulariseren** – Verplaats topbar, hoofdmenu en secundaire menu naar `_includes` (bijv. `topbar.html`, `primary-nav.html`, `secondary-nav.html`) en stuur hun inhoud via `_data/navigation.yml` zodat menu-items eenvoudig beheerd kunnen worden.
+3. **Hero & banner** – Maak een include voor de banner met configureerbare achtergrondafbeelding en titels, gevoed vanuit front matter of `_data/home.yml`. Zorg dat achtergrondafbeeldingen in `assets/images/` staan en in CSS/SCSS worden gestyled.
+4. **Hoofdcontent naar Markdown** – Zet de hoofdsecties (YouTube-embed, headings, paragrafen) om naar Markdown in `index.md`, gebruik Liquid-tags of shortcodes voor embeds.
+5. **Sidebar als component** – Gebruik `_includes/sidebar.html` met data-gestuurde widgets (donatiebanner, zoekformulier, recente posts, navigatielinks). Zo kunnen later andere pagina’s dezelfde sidebar hergebruiken.
+6. **Footer-widgets** – Modelleer de vierkoloms footer via `_includes/footer-widgets.html` en stuur inhoud via `_data/footer_widgets.yml` voor consistente styling.
+7. **Styling scheiden** – Maak `assets/css/main.scss` waarin je basisvariabelen (kleuren, lettertypen) en component-styles definieert. Zet responsive gedrag (zoals verborgen menu’s op mobiel) in SCSS in plaats van inline styles.
+8. **Contentmigratie** – Voor latere fases zorg je dat alle WordPress-inhoud (blogposts, componistenpagina’s) naar Markdown-bestanden in passende collecties gaat (`_posts`, `_composers`, etc.) met YAML-data voor metadata.
+
+## Current status
+
+- Een `default`-layout en kern-includes (topbar, navigatie, hero, sidebar, footer) vormen de basis van de homepage.
+- De eerste versie van `index.md` bevat de belangrijkste secties van de homepagina, inclusief een YouTube-embed via `_includes/youtube.html`.
+- `assets/css/main.scss` bevat de eerste opzet van typografie en component-styling die het uiterlijk van stabatmater.info benadert.
+- Verdere iteraties zullen de navigatie en widgets voeden vanuit `_data`, extra collecties toevoegen en inhoud migreren uit WordPress.
+
+## Handmatige media-bestanden
+
+De volgende afbeeldingen horen bij de lay-out maar zijn wegens PR-beperkingen niet opgenomen in de repository. Voeg ze handmatig toe na het clonen. Bewaar ze allemaal in `assets/images/`.
+
+| Bestand | Beschrijving | Plaats in de site |
+| --- | --- | --- |
+| `logo.png` | Transparant PNG-logo van *Stabat Mater Foundation* voor de primaire navigatiebalk. | Wordt geladen in `_includes/primary-nav.html` als merklogo linksboven. |
+| `hero-banner.jpg` | Full-width hero-achtergrond met een klassiek muziekoptreden. | Ingezet door `_includes/hero.html` als standaard hero-achtergrond. |
+| `hero-placeholder.jpg` | Alternatieve hero-afbeelding met een subtiel tekstuurpatroon voor pagina’s zonder specifieke banner. | Gebruik voor secundaire pagina’s via dezelfde hero-include. |
+| `flag-nl.png` | Klein Nederlands vlaggetje voor taalkeuze. | Getoond in `_includes/topbar.html` naast de taalwissel. |
+| `sidebar-donate.jpg` | Visuele banner met orkest voor de donatie-widget. | In `_includes/sidebar.html` als achtergrond voor de donatiecall-to-action. |
+| `footer-youtube.jpg` | Thumbnail van een kooroptreden. | Onderste kolom “YouTube” in `_includes/footer.html`. |
+| `footer-instagram.jpg` | Close-up foto uit een repetitie, afgestemd op Instagram-CTA. | Onderste kolom “Instagram” in `_includes/footer.html`. |
+| `footer-book.jpg` | Boekcover van *Stabat Mater Dolorosa*. | Onderste kolom “The book” in `_includes/footer.html`. |
+
+> **Let op:** zorg dat de bestandsnamen exact overeenkomen zodat de stijlen en includes zonder extra wijzigingen werken.
+
+## Getting started
+
+```bash
+bundle install
+bundle exec jekyll serve
+```
+
+De site is dan beschikbaar op <http://127.0.0.1:4000>. Gebruik `bundle exec jekyll build` om een productie-build te genereren.

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,15 @@
+name: The ultimate Stabat Mater site
+title: The ultimate Stabat Mater site
+url: ""
+baseurl: ""
+description: >-
+  Search our Stabat Mater Collection: 300 compositions, composers, texts and 24 translations of the original Latin poem Stabat Mater Dolorosa.
+markdown: kramdown
+highlighter: rouge
+permalink: pretty
+collections:
+  posts:
+    output: true
+sass:
+  sass_dir: assets/css
+  style: compressed

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,86 @@
+<h2 class="genesis-sidebar-title screen-reader-text">Footer</h2>
+<div class="wrap">
+  <div class="row gutter-xl">
+    <div class="widget-area footer-widgets-1 footer-widget-area col col-xs-12 col-sm-6 col-md-3">
+      <section class="widget widget_text">
+        <div class="widget-wrap">
+          <h3 class="widgettitle widget-title">Visit YouTube</h3>
+          <div class="textwidget">
+            <p>
+              <a href="https://www.youtube.com/channel/UCPUZ1hgQgIIYQeMqoJWWoXw" target="_blank" rel="noopener">
+                <img
+                  src="{{ '/assets/images/footer-youtube.jpg' | relative_url }}"
+                  alt="Visit YouTube"
+                  width="297"
+                  height="178"
+                />
+              </a><br />
+              <a href="https://www.youtube.com/channel/UCPUZ1hgQgIIYQeMqoJWWoXw" target="_blank" rel="noopener">Watch Stabat Mater performances</a>
+            </p>
+          </div>
+        </div>
+      </section>
+    </div>
+    <div class="widget-area footer-widgets-2 footer-widget-area col col-xs-12 col-sm-6 col-md-3">
+      <section class="widget widget_text">
+        <div class="widget-wrap">
+          <h3 class="widgettitle widget-title">Photos on Instagram</h3>
+          <div class="textwidget">
+            <p>
+              <a href="https://www.instagram.com/stabatmater.info/" target="_blank" rel="noopener">
+                <img
+                  src="{{ '/assets/images/footer-instagram.jpg' | relative_url }}"
+                  alt="Photos on Instagram"
+                  width="297"
+                  height="178"
+                />
+              </a><br />
+              <a href="https://www.instagram.com/stabatmater.info/" target="_blank" rel="noopener">Mary at the foot of the cross</a>
+            </p>
+          </div>
+        </div>
+      </section>
+    </div>
+    <div class="widget-area footer-widgets-3 footer-widget-area col col-xs-12 col-sm-6 col-md-3">
+      <section class="widget widget_text">
+        <div class="widget-wrap">
+          <h3 class="widgettitle widget-title">Stabat Mater Book</h3>
+          <div class="textwidget">
+            <p>
+              <a href="https://www.amazon.com/Stabat-Mater-Dolorosa-Journey-Centuries/dp/B0CY8T9MG1" target="_blank" rel="noopener">
+                <img
+                  src="{{ '/assets/images/footer-book.jpg' | relative_url }}"
+                  alt="Stabat Mater Book"
+                />
+              </a>
+              <a href="https://www.amazon.com/Stabat-Mater-Dolorosa-Journey-Centuries/dp/B0CY8T9MG1" target="_blank" rel="noopener">New Release: Stabat Mater Dolorosa</a>
+            </p>
+          </div>
+        </div>
+      </section>
+    </div>
+    <div class="widget-area footer-widgets-4 footer-widget-area col col-xs-12 col-sm-6 col-md-3">
+      <section class="widget widget_text">
+        <div class="widget-wrap">
+          <h3 class="widgettitle widget-title">Interested?</h3>
+          <div class="textwidget">
+            <p>Subscribe to the newsletter</p>
+            <form id="mc4wp-form-1" class="mc4wp-form" method="post" data-name="Newsletter">
+              <div class="mc4wp-form-fields">
+                <p>
+                  <label>Email address:<br />
+                    <input type="email" name="EMAIL" placeholder="Your email address" required />
+                  </label>
+                </p>
+                <p>
+                  <input type="submit" value="Sign up" />
+                </p>
+              </div>
+              <p class="visually-hidden">Leave this field empty if you're human: <input type="text" name="_mc4wp_honeypot" value="" tabindex="-1" autocomplete="off" /></p>
+            </form>
+          </div>
+        </div>
+      </section>
+    </div>
+  </div>
+</div>

--- a/_includes/hero.html
+++ b/_includes/hero.html
@@ -1,0 +1,16 @@
+{% assign hero = include.hero %}
+<section class="section banner-area width-full has-bg-image light-content" style="background-color: #f1f1f1;">
+  <picture class="bg-picture">
+    <source srcset="{{ hero.background | relative_url }}" media="(max-width: 800px)" />
+    <img
+      src="{{ hero.background | relative_url }}"
+      class="bg-image"
+      alt=""
+    />
+  </picture>
+  <div class="wrap height-lg center-xs text-xs-center text-lg">
+    <div class="section-content width-auto">
+      <h1 class="banner-title">{{ hero.title }}</h1>
+    </div>
+  </div>
+</section>

--- a/_includes/primary-nav.html
+++ b/_includes/primary-nav.html
@@ -1,0 +1,61 @@
+<div class="wrap">
+  <div class="site-header-row row middle-xs between-xs">
+    <div class="title-area col col-xs-auto start-xs">
+      <p class="site-title">
+        <a href="{{ '/' | relative_url }}" class="custom-logo-link" rel="home">
+          <img
+            src="{{ '/assets/images/logo.png' | relative_url }}"
+            class="custom-logo"
+            alt="The ultimate Stabat Mater site"
+          />
+        </a>
+      </p>
+      <p class="site-description screen-reader-text">a musical journey through the ages...</p>
+    </div>
+    <div class="header-right col col-xs text-xs-right">
+      <aside class="widget-area">
+        <section class="widget widget_text">
+          <div class="widget-wrap">
+            <div class="textwidget">
+              <p class="site-titel">The Ultimate Stabat Mater Website </p>
+              <p class="site-omschrijving">a musical journey through the ages</p>
+            </div>
+          </div>
+        </section>
+      </aside>
+    </div>
+  </div>
+  <div id="mai-menu" class="mai-menu">
+    <div class="mai-menu-outer">
+      <div class="mai-menu-inner">
+        <form class="search-form" method="get" action="{{ '/' | relative_url }}" role="search">
+          <label class="search-form-label screen-reader-text" for="searchform-2">Search this website</label>
+          <input class="search-form-input" type="search" name="s" id="searchform-2" placeholder="Search this website" />
+          <input class="search-form-submit" type="submit" value="Search" />
+          <meta content="{{ '/' | relative_url }}?s={s}" />
+        </form>
+        <div class="menu-hoofdmenu-container">
+          <ul id="menu-hoofdmenu" class="menu">
+            <li class="menu-item menu-item-home current-menu-item"><a href="{{ '/' | relative_url }}" aria-current="page">Home</a></li>
+            <li class="menu-item menu-item-has-children">
+              <a href="{{ '/stabat-mater-composer/' | relative_url }}">Composers</a>
+              <ul class="sub-menu">
+                <li class="menu-item"><a href="{{ '/stabat-mater-composer/alphabetically/' | relative_url }}">Alphabetically</a></li>
+                <li class="menu-item"><a href="{{ '/stabat-mater-composer/countries-of-origin/' | relative_url }}">By country of origin</a></li>
+                <li class="menu-item"><a href="{{ '/stabat-mater-composer/chronologically/' | relative_url }}">Chronologically</a></li>
+                <li class="menu-item"><a href="{{ '/stabat-mater-composer/duration/' | relative_url }}">By duration</a></li>
+              </ul>
+            </li>
+            <li class="menu-item"><a href="{{ '/stabat-mater-dolorosa-about-the-poem/' | relative_url }}">Texts</a></li>
+            <li class="menu-item"><a href="{{ '/stabat-mater-translations-and-languages/' | relative_url }}">Translations</a></li>
+            <li class="menu-item"><a href="{{ '/stabat-mater-blog/' | relative_url }}">Blog</a></li>
+            <li class="menu-item"><a href="{{ '/stabat-mater-cd-collection/' | relative_url }}">Missing CDs</a></li>
+            <li class="menu-item"><a href="{{ '/stabat-mater-foundation/' | relative_url }}">About</a></li>
+            <li class="menu-item"><a href="{{ '/stabat-mater-collection-support/' | relative_url }}">Donate?</a></li>
+            <li class="menu-item"><a href="{{ '/contact/' | relative_url }}">Contact</a></li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/_includes/secondary-nav.html
+++ b/_includes/secondary-nav.html
@@ -1,0 +1,23 @@
+<div class="wrap">
+  <ul id="menu-hoofdmenu-1" class="menu genesis-nav-menu menu-secondary responsive-menu">
+    <li class="menu-item menu-item-home current-menu-item">
+      <a href="{{ '/' | relative_url }}" aria-current="page">Home</a>
+    </li>
+    <li class="menu-item menu-item-has-children">
+      <a href="{{ '/stabat-mater-composer/' | relative_url }}">Composers</a>
+      <ul class="sub-menu">
+        <li class="menu-item"><a href="{{ '/stabat-mater-composer/alphabetically/' | relative_url }}">Alphabetically</a></li>
+        <li class="menu-item"><a href="{{ '/stabat-mater-composer/countries-of-origin/' | relative_url }}">By country of origin</a></li>
+        <li class="menu-item"><a href="{{ '/stabat-mater-composer/chronologically/' | relative_url }}">Chronologically</a></li>
+        <li class="menu-item"><a href="{{ '/stabat-mater-composer/duration/' | relative_url }}">By duration</a></li>
+      </ul>
+    </li>
+    <li class="menu-item"><a href="{{ '/stabat-mater-dolorosa-about-the-poem/' | relative_url }}">Texts</a></li>
+    <li class="menu-item"><a href="{{ '/stabat-mater-translations-and-languages/' | relative_url }}">Translations</a></li>
+    <li class="menu-item"><a href="{{ '/stabat-mater-blog/' | relative_url }}">Blog</a></li>
+    <li class="menu-item"><a href="{{ '/stabat-mater-cd-collection/' | relative_url }}">Missing CDs</a></li>
+    <li class="menu-item"><a href="{{ '/stabat-mater-foundation/' | relative_url }}">About</a></li>
+    <li class="menu-item"><a href="{{ '/stabat-mater-collection-support/' | relative_url }}">Donate?</a></li>
+    <li class="menu-item"><a href="{{ '/contact/' | relative_url }}">Contact</a></li>
+  </ul>
+</div>

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,0 +1,48 @@
+<section id="text-60" class="widget boxed widget_text">
+  <div class="widget-wrap">
+    <div class="textwidget">
+      <p>
+        <a href="{{ '/stabat-mater-collection-support/' | relative_url }}">
+          <img
+            src="{{ '/assets/images/sidebar-donate.jpg' | relative_url }}"
+            alt="Donate to the Stabat Mater Collection"
+            width="300"
+            height="175"
+          />
+        </a>
+      </p>
+    </div>
+  </div>
+</section>
+<section id="search-5" class="widget boxed widget_search">
+  <div class="widget-wrap">
+    <form class="search-form" method="get" action="{{ '/' | relative_url }}" role="search">
+      <label class="search-form-label screen-reader-text" for="searchform-3">Search this website</label>
+      <input class="search-form-input" type="search" name="s" id="searchform-3" placeholder="Search this website" />
+      <input class="search-form-submit" type="submit" value="Search" />
+      <meta content="{{ '/' | relative_url }}?s={s}" />
+    </form>
+  </div>
+</section>
+<section id="recent-posts-2" class="widget boxed widget_recent_entries">
+  <div class="widget-wrap">
+    <h3 class="widgettitle widget-title">Recent posts</h3>
+    <ul>
+      <li class="placeholder">Latest news posts will appear here once the collection has been migrated.</li>
+    </ul>
+  </div>
+</section>
+<section id="text-28" class="widget boxed widget_text">
+  <div class="widget-wrap">
+    <h3 class="widgettitle widget-title">Stabat Mater composers</h3>
+    <div class="textwidget">
+      <p>
+        Search for composers:<br />
+        <a href="{{ '/composer/alphabetically/' | relative_url }}">Alphabetically</a><br />
+        <a href="{{ '/composer/countries-of-origin/' | relative_url }}">By countries of origin</a><br />
+        <a href="{{ '/composer/chronologically/' | relative_url }}">Chronologically</a><br />
+        <a href="{{ '/composer/duration/' | relative_url }}">By duration</a>
+      </p>
+    </div>
+  </div>
+</section>

--- a/_includes/topbar.html
+++ b/_includes/topbar.html
@@ -1,0 +1,36 @@
+<div class="wrap">
+  <ul id="menu-topmenu" class="menu genesis-nav-menu menu-third responsive-menu">
+    <li class="menu-item menu-item-type-post_type menu-item-object-page">
+      <a href="{{ '/stabat-mater-collection-support/' | relative_url }}">Donate</a>
+    </li>
+    <li class="instagram menu-item menu-item-type-custom menu-item-object-custom">
+      <a href="https://www.instagram.com/stabatmater.info/">
+        <span class="menu-image-title-hide menu-image-title">instagram</span>
+        <span class="dashicons dashicons-instagram hide-menu-image-icons" aria-hidden="true"></span>
+      </a>
+    </li>
+    <li class="youtube menu-item menu-item-type-custom menu-item-object-custom">
+      <a href="https://www.youtube.com/channel/UCPUZ1hgQgIIYQeMqoJWWoXw">
+        <span class="menu-image-title-hide menu-image-title">Youtube</span>
+        <span class="dashicons dashicons-video-alt3 hide-menu-image-icons" aria-hidden="true"></span>
+      </a>
+    </li>
+    <li class="twitter menu-item menu-item-type-custom menu-item-object-custom">
+      <a href="https://twitter.com/StabatMaterSite">
+        <span class="menu-image-title-hide menu-image-title">Twitter</span>
+        <span class="dashicons dashicons-twitter hide-menu-image-icons" aria-hidden="true"></span>
+      </a>
+    </li>
+    <li class="menu-item wpml-ls-item">
+      <a href="{{ '/nl/' | relative_url }}" title="Switch to">
+        <img
+          class="wpml-ls-flag"
+          src="{{ '/assets/images/flag-nl.png' | relative_url }}"
+          alt="Dutch"
+          width="18"
+          height="12"
+        />
+      </a>
+    </li>
+  </ul>
+</div>

--- a/_includes/youtube.html
+++ b/_includes/youtube.html
@@ -1,0 +1,17 @@
+<figure class="wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio">
+  <div class="wp-block-embed__wrapper">
+    <iframe
+      title="{{ include.title | default: 'YouTube video player' }}"
+      width="500"
+      height="281"
+      src="https://www.youtube.com/embed/{{ include.id }}?feature=oembed"
+      frameborder="0"
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+      referrerpolicy="strict-origin-when-cross-origin"
+      allowfullscreen
+    ></iframe>
+  </div>
+  {% if include.caption %}
+    <figcaption class="wp-element-caption">{{ include.caption }}</figcaption>
+  {% endif %}
+</figure>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{% if page.title %}{{ page.title }} · {% endif %}{{ site.title }}</title>
+    <meta name="description" content="{{ page.excerpt | default: site.description | strip_html | normalize_whitespace }}" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Domine:wght@400&family=Poppins:wght@400&family=Roboto+Slab:wght@700&family=Source+Sans+Pro:wght@300;400;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="https://s.w.org/wp-includes/css/dashicons.css" />
+    <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}" />
+  </head>
+  <body class="home wp-singular page-template-default page has-banner-area has-sidebar">
+    <nav class="nav-third">
+      {% include topbar.html %}
+    </nav>
+    <div class="site-container">
+      <header class="site-header has-header-right">
+        {% include primary-nav.html %}
+      </header>
+      {% if page.hero %}
+        {% include hero.html hero=page.hero %}
+      {% endif %}
+      <nav class="nav-secondary">
+        {% include secondary-nav.html %}
+      </nav>
+      <div class="site-inner">
+        <header class="entry-header">
+          <h1 class="entry-title">{{ page.title }}</h1>
+        </header>
+        <div class="content-sidebar-wrap has-boxed-children">
+          <main class="content" id="genesis-content">
+            <article class="entry boxed">
+              <div class="entry-content">
+                {{ content }}
+              </div>
+            </article>
+          </main>
+          <aside class="sidebar sidebar-primary widget-area has-boxed" role="complementary" aria-label="Primary Sidebar" id="genesis-sidebar-primary">
+            {% include sidebar.html %}
+          </aside>
+        </div>
+      </div>
+      <div class="footer-widgets" id="genesis-footer-widgets">
+        {% include footer.html %}
+      </div>
+      <footer class="site-footer text-sm">
+        <div class="wrap">
+          <div class="creds">
+            <p>&copy; {{ site.time | date: '%Y' }}  · <a href="{{ '/nl/copyright/' | relative_url }}" target="_blank">Copyright</a>  <a href="{{ '/nl/privacy/' | relative_url }}" target="_blank">Privacy</a> <a href="{{ '/nl/disclaimer/' | relative_url }}" target="_blank">Disclaimer</a>  · Bouw: <a href="https://www.bronwasserwebsites.nl" target="_blank">Bronwasser Websites</a> in <a href="https://wordpress.org/" target="_blank">WordPress</a></p>
+          </div>
+        </div>
+      </footer>
+    </div>
+    <div class="wpml-ls-statics-footer wpml-ls wpml-ls-legacy-list-horizontal">
+      <ul>
+        <li class="wpml-ls-slot-footer wpml-ls-item wpml-ls-item-nl wpml-ls-first-item wpml-ls-last-item wpml-ls-item-legacy-list-horizontal">
+          <a href="{{ '/nl/' | relative_url }}" class="wpml-ls-link">
+            <img
+              class="wpml-ls-flag"
+              src="{{ '/assets/images/flag-nl.png' | relative_url }}"
+              alt="Dutch"
+              width="18"
+              height="12"
+            />
+          </a>
+        </li>
+      </ul>
+    </div>
+  </body>
+</html>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1,0 +1,618 @@
+---
+---
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Source Sans Pro', sans-serif;
+  font-weight: 400;
+  font-size: 13px;
+  background: #ffffff;
+  color: #323232;
+  line-height: 1.625;
+}
+
+h1,
+.banner-title,
+.heading,
+.widget-title,
+.widgettitle,
+.entry-title,
+h2,
+h3,
+h4,
+h5 {
+  font-family: 'Domine', serif;
+  letter-spacing: 0;
+}
+
+h1,
+.banner-title,
+.heading,
+.entry-title {
+  font-weight: 400;
+  font-size: 1.9rem;
+}
+
+h2 {
+  font-weight: 300;
+  font-size: 1.3rem;
+}
+
+h3 {
+  font-family: 'Source Sans Pro', sans-serif;
+  letter-spacing: 0;
+  font-size: 1.15rem;
+  font-weight: 600;
+  margin-bottom: 12px;
+}
+
+h3.widgettitle,
+.widget-title,
+.widgettitle {
+  font-family: 'Domine', serif;
+  font-size: 1.3rem;
+  font-weight: 300;
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+}
+
+a {
+  color: #aa2c0d;
+  text-decoration: underline;
+}
+
+a:hover {
+  color: #aaaaaa;
+}
+
+.visually-hidden,
+.screen-reader-text {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.wrap {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+.row {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.col {
+  display: block;
+}
+
+.middle-xs {
+  align-items: center;
+}
+
+.between-xs {
+  justify-content: space-between;
+}
+
+.start-xs {
+  justify-content: flex-start;
+}
+
+.text-xs-right {
+  text-align: right;
+}
+
+.center-xs {
+  justify-content: center;
+  text-align: center;
+}
+
+.height-lg {
+  min-height: 320px;
+}
+
+.menu {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.menu li {
+  position: relative;
+}
+
+.menu a {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  text-decoration: none;
+  color: inherit;
+}
+
+.menu .sub-menu {
+  display: none;
+  position: absolute;
+  top: 100%;
+  left: 0;
+  z-index: 10;
+  background: #ffffff;
+  border: 1px solid #dbe4e0;
+  padding: 10px 0;
+  list-style: none;
+  min-width: 220px;
+}
+
+.menu .sub-menu li {
+  width: 100%;
+}
+
+.menu .sub-menu a {
+  width: 100%;
+  padding: 8px 16px;
+  color: #333333;
+  text-transform: none;
+}
+
+.menu li:hover > .sub-menu {
+  display: block;
+}
+
+.nav-third {
+  border-bottom: 1px solid #e1e1e1;
+}
+
+.nav-third > .wrap {
+  padding-left: 24px;
+  padding-right: 24px;
+}
+
+.nav-third .menu {
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.nav-third .menu a {
+  color: #333333;
+  font-size: 0.875rem;
+  letter-spacing: 0.5px;
+  padding: 14px 5px;
+  text-transform: uppercase;
+}
+
+#menu-topmenu.genesis-nav-menu a {
+  padding: 14px 5px;
+}
+
+.nav-third .dashicons {
+  font-size: 16px;
+}
+
+.site-header {
+  background: transparent;
+  padding: 30px 0 0;
+  position: relative;
+  z-index: 5;
+}
+
+.site-header-row {
+  align-items: flex-start;
+  gap: 24px;
+}
+
+.site-header .text-xs-right {
+  text-align: left;
+}
+
+.site-title {
+  margin: 0;
+}
+
+.custom-logo {
+  max-width: 250px;
+  height: auto;
+}
+
+.site-titel {
+  font-family: 'Domine', serif;
+  font-size: 38px;
+  font-weight: 400;
+  letter-spacing: 1px;
+  margin: 0;
+  line-height: 1;
+}
+
+.site-omschrijving {
+  font-family: 'Domine', serif;
+  font-size: 30px;
+  font-weight: 400;
+  letter-spacing: 1px;
+  margin: 0;
+}
+
+.header-right .widget-area {
+  margin-top: 10px;
+}
+
+#mai-menu {
+  margin-top: 16px;
+}
+
+#mai-menu .menu {
+  justify-content: flex-start;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+#mai-menu .menu > li > a {
+  font-family: 'Domine', serif;
+  font-size: 0.9375rem;
+  font-weight: 400;
+  text-transform: uppercase;
+  color: #333333;
+  padding: 12px 0;
+}
+
+.search-form {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 16px;
+}
+
+.search-form-input {
+  flex: 1 1 240px;
+  padding: 10px 12px;
+  border: 1px solid #cccccc;
+  font-size: 16px;
+  border-radius: 2px;
+}
+
+.search-form-submit {
+  background: #aa2c0d;
+  color: #ffffff;
+  border: none;
+  padding: 10px 20px;
+  font-family: 'Domine', serif;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.search-form-submit:hover {
+  background: #8c230a;
+}
+
+.section.banner-area {
+  background-color: #f1f1f1;
+  margin-top: -200px;
+  max-height: 250px;
+  overflow: hidden;
+  position: relative;
+  z-index: 0;
+}
+
+.banner-area .bg-image {
+  width: 100%;
+  height: auto;
+  object-fit: cover;
+}
+
+.banner-area .wrap {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
+.banner-area .banner-title {
+  display: none;
+}
+
+.nav-secondary {
+  background: #2f6654;
+}
+
+.nav-secondary .menu {
+  justify-content: flex-start;
+  gap: 16px;
+  padding: 14px 0;
+}
+
+.nav-secondary .menu > li > a {
+  color: #ffffff;
+  font-family: 'Domine', serif;
+  font-size: 0.875rem;
+  text-transform: uppercase;
+  padding: 4px 12px;
+}
+
+.nav-secondary .menu > li > a:hover,
+.nav-secondary .menu > li.current-menu-item > a {
+  background: #dbe4e0;
+  color: #2f6654;
+  border-radius: 2px;
+}
+
+.nav-secondary .menu .sub-menu {
+  background: #2f6654;
+}
+
+.nav-secondary .menu .sub-menu a {
+  background: #2f6654;
+  color: #ffffff;
+}
+
+.nav-secondary .menu .sub-menu a:hover {
+  background: #dbe4e0;
+  color: #2f6654;
+}
+
+.site-inner {
+  background: #ffffff;
+  padding: 40px 0 60px;
+}
+
+.entry-header {
+  margin-bottom: 24px;
+}
+
+.entry-title {
+  font-family: 'Domine', serif;
+  font-size: 1.9rem;
+  font-weight: 400;
+  letter-spacing: 0;
+  margin: 0;
+}
+
+.content-sidebar-wrap {
+  display: flex;
+  gap: 40px;
+}
+
+.content {
+  flex: 1 1 0;
+  max-width: 720px;
+}
+
+.entry-content {
+  font-size: 18px;
+}
+
+.entry-content p {
+  margin: 0 0 20px;
+}
+
+.entry-content h2.wp-block-heading {
+  font-family: 'Domine', serif;
+  font-size: 1.3rem;
+  font-weight: 300;
+  margin: 32px 0 12px;
+}
+
+.wp-block-embed {
+  background: #f8f8f8;
+  border: 1px solid #e0e0e0;
+  padding: 24px;
+  margin-bottom: 24px;
+}
+
+.wp-block-embed__wrapper {
+  position: relative;
+  padding-bottom: 56.25%;
+  height: 0;
+}
+
+.wp-block-embed__wrapper iframe {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.wp-element-caption {
+  font-family: 'Poppins', sans-serif;
+  font-size: 14px;
+  color: #333333;
+  margin-top: 12px;
+}
+
+.sidebar {
+  flex: 0 0 320px;
+  max-width: 320px;
+}
+
+.sidebar .widget {
+  border: 1px solid #e5e5e5;
+  padding: 24px;
+  background: #ffffff;
+  margin-bottom: 24px;
+}
+
+.sidebar .widgettitle {
+  font-family: 'Domine', serif;
+  font-size: 1.3rem;
+  font-weight: 300;
+  text-transform: none;
+  letter-spacing: 0;
+  margin: 0 0 16px;
+}
+
+.sidebar .textwidget p {
+  margin: 0 0 12px;
+  font-size: 16px;
+}
+
+.widget_recent_entries ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.widget_recent_entries li {
+  margin-bottom: 16px;
+  font-size: 16px;
+}
+
+.widget_recent_entries li.placeholder {
+  color: #6a6a6a;
+  font-style: italic;
+}
+
+.widget_recent_entries .post-date {
+  display: block;
+  font-size: 14px;
+  color: #6a6a6a;
+}
+
+.footer-widgets {
+  background: #f9f4f2;
+  padding: 40px 0;
+}
+
+.footer-widgets .row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 24px;
+}
+
+.footer-widgets .widget {
+  border: none;
+  background: transparent;
+  padding: 0;
+  color: #333333;
+}
+
+.footer-widgets .widget-title {
+  font-family: 'Roboto Slab', serif;
+  font-size: 22px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  margin-bottom: 16px;
+}
+
+.footer-widgets .textwidget p {
+  margin: 0 0 12px;
+  font-size: 16px;
+}
+
+.mc4wp-form-fields p {
+  margin: 0 0 12px;
+}
+
+.mc4wp-form input[type='email'] {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid #cccccc;
+  font-size: 16px;
+}
+
+.mc4wp-form input[type='submit'] {
+  background: #aa2c0d;
+  color: #ffffff;
+  border: none;
+  padding: 10px 20px;
+  font-family: 'Poppins', sans-serif;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.mc4wp-form input[type='submit']:hover {
+  background: #8c230a;
+}
+
+.site-footer {
+  background: #aa2c0d;
+  color: #ffffff;
+  padding: 20px 0;
+}
+
+.site-footer a {
+  color: #ffffff;
+}
+
+.site-footer .creds {
+  font-size: 14px;
+  text-align: center;
+  margin: 0;
+}
+
+.wpml-ls-statics-footer {
+  background: #aa2c0d;
+  padding: 12px 0;
+  text-align: center;
+}
+
+.wpml-ls-statics-footer ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: inline-flex;
+  gap: 10px;
+}
+
+@media (max-width: 960px) {
+  .site-header-row {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  #mai-menu .menu {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .content-sidebar-wrap {
+    flex-direction: column;
+  }
+
+  .sidebar {
+    max-width: 100%;
+    flex: 1 1 auto;
+  }
+
+  .section.banner-area {
+    margin-top: 0;
+  }
+}
+
+@media (max-width: 640px) {
+  .nav-third .menu {
+    justify-content: center;
+  }
+
+  .banner-title {
+    font-size: 28px;
+  }
+
+  .entry-title {
+    font-size: 26px;
+  }
+
+  .entry-content {
+    font-size: 16px;
+  }
+
+  .entry-content h2.wp-block-heading {
+    font-size: 20px;
+  }
+}

--- a/assets/images/.gitkeep
+++ b/assets/images/.gitkeep
@@ -1,0 +1,1 @@
+(plaats houders voor afbeeldingen)

--- a/index.md
+++ b/index.md
@@ -1,0 +1,18 @@
+---
+layout: default
+title: Explore the Timeless Legacy of the Stabat Mater
+hero:
+  title: Explore the Timeless Legacy of the Stabat Mater
+  background: /assets/images/hero-banner.jpg
+---
+
+{% include youtube.html id="BB51Wb2UvbI" title="Stabat Mater Dolorosa - A Journey through Seven Centuries of Music" caption="<strong>If you would like to support us</strong> in keeping the website ad-free, you might consider making a <a href='{{ '/stabat-mater-collection-support/' | relative_url }}'>donation</a> or purchasing the <a href='https://www.amazon.com/Stabat-Mater-Dolorosa-Journey-Centuries/dp/B0CY8T9MG1'>Stabat Mater Dolorosa book</a>. Thank you so much!" %}
+
+<h2 class="wp-block-heading">Search the Ultimate Stabat Mater Website</h2>
+<p>On the Ultimate Stabat Mater Website you will find the CD-collection of -now- more than 300 different Stabat Mater compositions. Search for <a href="{{ '/stabat-mater-composer/' | relative_url }}">composers</a>: alphabetically, chronologically, by country of origin and by duration. <a href="https://www.youtube.com/channel/UCPUZ1hgQgIIYQeMqoJWWoXw">Listen</a> to the compositions and <a href="https://www.youtube.com/channel/UCPUZ1hgQgIIYQeMqoJWWoXw/featured">watch</a> the videos of special performances. The site also includes <a href="{{ '/stabat-mater-translations-and-languages/' | relative_url }}">translations</a> of the original Latin poem <a href="{{ '/stabat-mater-dolorosa-about-the-poem/' | relative_url }}">Stabat Mater Dolorosa</a> in 24 different languages. See: <a href="{{ '/category/latest-addition/' | relative_url }}">Latest additions</a>.</p>
+
+<h2 class="wp-block-heading">Why this Stabat Mater website?&nbsp;&nbsp;</h2>
+<p>Initiator of this website, <a href="{{ '/stabat-mater-foundation/' | relative_url }}">Hans van der Velden</a>, began this journey of musical discovery in 1992 with the Stabat Mater from <a href="{{ '/stabat-mater-foundation/' | relative_url }}">Haydn</a>. He searched systematically and persistently for composers, performances on cd and translations of the original Latin poem. He brought the religious, literary, and musical world of the Stabat Mater to life. <a href="{{ '/stabat-mater-foundation/' | relative_url }}">We are proud</a> to continue his work.</p>
+
+<h2 class="wp-block-heading">Interested?</h2>
+<p>We hope this site is helpful for music lovers, musicians, and composers! Would you like to learn more? Subscribe to the Newsletter or <a href="{{ '/stabat-mater-blog/' | relative_url }}">read the blog</a>. Do you have any information about performances, recordings, video’s, or cds with Stabat Maters? <a href="{{ '/contact/' | relative_url }}">Please, let us know</a>!</p>


### PR DESCRIPTION
## Summary
- remove binary image assets so the branch stays text-only for browser-based PR tooling
- add a placeholder `.gitkeep` so the `assets/images/` directory persists without binaries
- document each required media file in the README with placement and description for manual upload

## Testing
- bundle exec jekyll build

------
https://chatgpt.com/codex/tasks/task_e_68d987502b60833387542ac8e0aa4cee