### PR TITLE
Configure production URLs for GitHub Pages deployment

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 name: The ultimate Stabat Mater site
 title: The ultimate Stabat Mater site
-url: ""
-baseurl: ""
+url: "https://mrnspam.github.io"
+baseurl: "/stabmat-redo"
 description: >-
   Search our Stabat Mater Collection: 300 compositions, composers, texts and 24 translations of the original Latin poem Stabat Mater Dolorosa.
 markdown: kramdown


### PR DESCRIPTION
## Summary
- set the Jekyll site url and baseurl for the GitHub Pages host

## Testing
- bundle exec jekyll build

------
https://chatgpt.com/codex/tasks/task_e_68d9b2a1f03483338de26aef2daa1404