### PR TITLE
Center site inner content within wrap

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -29,20 +29,22 @@
         {% include secondary-nav.html %}
       </nav>
       <div class="site-inner">
-        <header class="entry-header">
-          <h1 class="entry-title">{{ page.title }}</h1>
-        </header>
-        <div class="content-sidebar-wrap has-boxed-children">
-          <main class="content" id="genesis-content">
-            <article class="entry boxed">
-              <div class="entry-content">
-                {{ content }}
-              </div>
-            </article>
-          </main>
-          <aside class="sidebar sidebar-primary widget-area has-boxed" role="complementary" aria-label="Primary Sidebar" id="genesis-sidebar-primary">
-            {% include sidebar.html %}
-          </aside>
+        <div class="wrap">
+          <header class="entry-header">
+            <h1 class="entry-title">{{ page.title }}</h1>
+          </header>
+          <div class="content-sidebar-wrap has-boxed-children">
+            <main class="content" id="genesis-content">
+              <article class="entry boxed">
+                <div class="entry-content">
+                  {{ content }}
+                </div>
+              </article>
+            </main>
+            <aside class="sidebar sidebar-primary widget-area has-boxed" role="complementary" aria-label="Primary Sidebar" id="genesis-sidebar-primary">
+              {% include sidebar.html %}
+            </aside>
+          </div>
         </div>
       </div>
       <div class="footer-widgets" id="genesis-footer-widgets">

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -372,6 +372,10 @@ a:hover {
   padding: 40px 0 60px;
 }
 
+.site-inner > .wrap {
+  padding: 0 24px;
+}
+
 .entry-header {
   margin-bottom: 24px;
 }


### PR DESCRIPTION
## Summary
- wrap the entry header and content/sidebar section in a shared `.wrap` container to align them with other centered areas
- ensure the new wrapper retains existing horizontal padding within `.site-inner`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da6930644c833391eda5629d77e0c8