### PR TITLE
Further tighten home site-inner spacing

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -372,6 +372,10 @@ a:hover {
   padding: 40px 0 60px;
 }
 
+.home .site-inner {
+  padding-top: 0;
+}
+
 .site-inner > .wrap {
   padding: 0 24px;
 }


### PR DESCRIPTION
## Summary
- drop the home page `.site-inner` top padding to 0 so the content hugs the nav like the reference

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da769ec4b88333a3ed7408c6091ea7