### PR TITLE
Convert composer profiles from HTML to Markdown

### DIFF
--- a/_composers/alessandro-scarlatti.md
+++ b/_composers/alessandro-scarlatti.md
@@ -1,0 +1,38 @@
+---
+title: Scarlatti, Alessandro
+slug: alessandro-scarlatti
+source_url: https://stabatmater.info/componist/scarlatti/
+---
+
+# Alessandro Scarlatti
+
+## About the composer
+
+Alessandro Scarlatti (1660 – 1725) was born in Palermo, Italy. He was one of the first exponents of the Neapolitan School (see also Salvatori). He composed over 600 cantatas, 150 oratories and 115 operas. The Stabat Mater was composed for the Order of “Cavalieri della Virgine dei Dolori” in Naples, who, annually, honored the Virgin by dedicating to her, during the Lenten season, a Stabat Mater. The Order was very poor, what may be the explanation for the small number of artists the score was written for. Many years later, probably in 1734, the same Order commissioned Pergolesi for a new Stabat Mater.
+
+## About the Stabat Mater
+
+| Field | Details |
+| --- | --- |
+| **Date** | 1723 |
+| **Performers** | Soprano, alto and continuo (2 violins, cello, organ) |
+| **Length** | 46.22 minutes |
+| **Particulars** | The work is divided into four sections and the music is varied in form, going from simple recitatives to more developed operatic arias where the text is repeated three times, ultimately ending with a great fugue on the final "Amen". |
+| **Textual variations** | The "Analecta"-version of the text is sung, but surprisingly Scarlatti changes around the stanzas 10 and 11, and also the stanzas 13 and 14. Only one other change:<br />- Stanza 16, line 2: not "Passionis eius sortem" but "Passionis fac consortem" |
+| **Colour bar** | ![Colour bar for Alessandro Scarlatti](https://stabatmater.info/wp-content/uploads/colorbar/scarlata.gif) |
+
+## Information about the recording
+
+| Field | Details |
+| --- | --- |
+| **CD** | Ades 204752, Scarlatti, Stabat Mater |
+| **More info** | Recorded at the Eglise Evangélique Saint Jean de Grenelle, Paris, in August 1988. |
+| **Orchestra** | Ensemble Gradiva |
+| **Conductor** | Alain Zaepffel |
+| **Soloists** | Véronique Dietschy, soprano<br />Alain Zaepffel, countertenor |
+| **Other works** | Salve Regina |
+| **Code** | SCA-02 |
+
+## Listen
+
+<iframe allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen frameborder="0" height="253" loading="lazy" referrerpolicy="strict-origin-when-cross-origin" src="https://www.youtube.com/embed/eKEp72EcnsM?feature=oembed" title="Stabat Mater - Alessandro Scarlatti" width="450"></iframe>

--- a/_composers/antonio-vivaldi.md
+++ b/_composers/antonio-vivaldi.md
@@ -1,0 +1,64 @@
+---
+title: Vivaldi, Antonio
+slug: antonio-vivaldi
+source_url: https://stabatmater.info/componist/antonio-vivaldi/
+---
+
+# Antonio Vivaldi
+
+## About the composer
+
+Antonio Vivaldi (1678 – 1741) was probably born in Venice, Italy. The priest Vivaldi, in view of his wild red hair often called “the red priest” (Il Preto Rosso), worked the largest part of his life as a music master at the *Ospedale della Pietà* in Venice, originally an orphanage for extra-marital girls. For an important part this may not only have influenced the score of his works (there were only women to play and sing), but could also be the reason for the fact that he frequently made use of easy to listen to melodies, as these were mostly intended for a young female audience. His most famous work, of course, is *Le Quattro Stagioni* (The Four Seasons). He died in Vienna, during one of his journeys. The first movement of Vivaldi’s Stabat Mater has been used in the soundtrack of the movie “The talented Mr.Ripley”.
+
+## About the Stabat Mater
+
+| Field | Details |
+| --- | --- |
+| **Date** | ca. 1727 |
+| **Performers** | Alto, strings and continuo |
+| **Length** | CD 1: 21.21 minutes,  CD 2: 18.37 minutes and CD 3: 18.30 minutes |
+| **Particulars** | The composition is divided into eight sections. The melodies of sections 1 to 3 are repeated in sections 4 to 6. For me, this Stabat Mater is one of the most beautiful ever composed. The singers in the first two registrations that I possess differ greatly with respect to their voices, but both sing marvelous. You should hear them both! |
+| **Textual variations** | Only the first ten stanzas are used. It seems that for some time shorter versions of the Stabat Mater were used as a hymn for Vespers for the Friday after Holy Week. |
+| **Colour bar** | ![Colour bar for Antonio Vivaldi](https://stabatmater.info/wp-content/uploads/colorbar/vivaldi.gif) |
+
+## Information about the recording
+
+### CD 1
+
+| Field | Details |
+| --- | --- |
+| **CD** | EMI Classics 7243565845 2 (2 CD’s) Stabat Mater |
+| **More info** | Five completely different settings of the Stabat Mater. A “must” for every collector, especially as it has the only performance of Schubert’s Stabat Mater D.175. The Stabat Maters were recorded in 1982/83. Vivaldi’s Stabat Mater is performed here by one of the most highly regarded Dutch singers. |
+| **Orchestra** | Les Solistes de Milan |
+| **Conductor** | Angelo Ephrikian |
+| **Soloists** | Aafje Heynis, alto |
+| **Other works** | Franz Schubert: Stabat Maters D.175 and D.383<br />Gioacchino Rossini: Stabat Mater<br />Giuseppe Verdi: Stabat Mater |
+| **Code** | SCH-04 |
+
+### CD 2
+
+| Field | Details |
+| --- | --- |
+| **CD** | Harmonia Mundi HMC 901571: Vivaldi, Stabat Mater |
+| **More info** | An interpretation by a singer who is generally regarded as one of the worlds greatest countertenors. Recorded in June 1995. |
+| **Orchestra** | Ensemble 415 |
+| **Conductor** | Chiara Banchini |
+| **Soloists** | Andreas Scholl, countertenor |
+| **Other works** | Concerto ripieno in C major, RV 114<br />Cantate "Cessate, omai cessate" RV 684<br />Sonata a quatro "Al Santo Sepulcro" RV 130<br />Introduzione al miserere "Filiae Maestae Jerusalem" RV 638 |
+| **Code** | 1996 VIV-04 |
+
+### CD 3
+
+| Field | Details |
+| --- | --- |
+| **CD** | Naïve OP 30453 Vivaldi |
+| **More info** | I received This cd fom my friend Daisy Mottier from Switzerland. I met her because of her interesting project [Painting – Music Dialogues](http://www.daisymottier.ch/Stabat_Mater.htm). |
+| **Orchestra** | Ensemble Mattheus |
+| **Conductor** | Jean Christoph Spinosi |
+| **Soloists** | Marie Nicole Lemieux |
+| **Other works** | Vivaldi: Nisi Dominus, Crucifixus (from the Credo) |
+| **Code** | 2013 VIV-13 |
+
+## Listen
+
+<iframe allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen frameborder="0" height="253" loading="lazy" referrerpolicy="strict-origin-when-cross-origin" src="https://www.youtube.com/embed/QcNyOyO6Yc4?feature=oembed" title="Stabat Mater   Antonio Vivaldi" width="450"></iframe>

--- a/_composers/gioachino-rossini.md
+++ b/_composers/gioachino-rossini.md
@@ -1,0 +1,73 @@
+---
+title: Rossini, Gioacchino
+slug: gioachino-rossini
+source_url: https://stabatmater.info/componist/rossini/
+---
+
+# Gioacchino Rossini
+
+## About the composer
+
+Gioacchino Rossini (1792 – 1868) was born in Pesaro, Italy. In view of his background of composing mainly comic operas the few religious compositions of Rossini (*Petite Messe Solennelle*, *Stabat Mater*) are sometimes criticized as less serious. Notwithstanding the strong operatic tendencies, especially in the Stabat Mater, this was absolutely not Rossini’s intention. To the contrary, as we can learn from his note to the manuscript of the Petite Messe, he composed these works from a real religious feeling: “*Here it is then, this poor little Mass. Have I written truly sacred music, or just damn bad music? I was born for opera buffa, as you well know. Not much skill, but quite a bit of feeling – that’s how I’d sum it up. Blessed be thy name, and grant me a place in Paradise*“. At first Rossini composed only sections 1 and 5 through 9 from the intended ten sections of his Stabat Mater. Due to an attack of lumbago, either real or strategic (Rossini was not very motivated, in the beginning), the other sections were composed by Giovanni Tadolini from Bologna. In this form it was played in Madrid in 1832. However, before it could be published Rossini succeeded in getting back the manuscript and re-composed the Tadolini-sections. In 1842 it had its premiere in its definite form. An instrumental paraphrase *Fantasia su motivi dello Stabat Mater di Rossini* was written some years later by Saverio [Mercadante](https://stabatmater.info/mercadante.htm).
+
+## About the Stabat Mater
+
+| Field | Details |
+| --- | --- |
+| **Date** | 1837 |
+| **Performers** | Soprano, alto, tenor, bass, mixed choir and orchestra |
+| **Length** | CD 1: 61.05 minutes, CD 2: 59.23 minutes, CD 3: 65.03 minutes, CD 4: 59.27 minutes |
+| **Particulars** | The poet Heine wrote after hearing the Stabat Mater that the theater seemed "a vestibule of heaven". The audiences were deeply moved by the somber beauty of the long opening and taken by the beautiful melodies of the following movements. As evidence of Rossini's serious purpose the work ends with a great double fugue. |
+| **Textual variations** | The "Analecta"-version of the text is used, with following changes:<br />- Stanza 16, line 2: not "Passionis eius sortem" but "Passionis fac consortem"<br />- After the "Amen" Rossini adds the line "In sempiterna saecula" (In all eternity) |
+| **Colour bar** | ![Colour bar for Gioacchino Rossini](https://stabatmater.info/wp-content/uploads/colorbar/rossini.gif) |
+
+## Information about the recording
+
+### CD 1 — EMI Classics 7243 5 65845 2 (double CD): *Stabat Mater* – Rossini, Schubert, Vivaldi, Verdi
+
+- **More info:** Five completely different settings of the Stabat Mater. A “must” for every collector, especially as it has the only performance of Schubert’s Stabat Mater D.175. The Rossini Stabat Mater was recorded in November 1982.
+- **Orchestra:** Orchestra del Maggio Musicale Fiorentino
+- **Choir:** Coro del Maggio Musicale Fiorentino
+- **Conductor:** Riccardo Muti
+- **Soloists:** Catherina Malfitano, soprano; Agnes Baltsa, mezzo-soprano; Robert Gambill, tenor; Gwynne Howell, bass
+- **Other works:** Giuseppe Verdi, *Stabat Mater*; Franz Schubert, *Stabat Mater* D.175; Franz Schubert, *Stabat Mater* D.383; Antonio Vivaldi, *Stabat Mater*
+- **Code:** SCH-04
+
+### CD 2 — Deutsche Grammophon 449 178-2: Rossini, *Stabat Mater*
+
+- **More info:** A good performance with top soloists. Recorded at the Grosser Saal der Musikverein, Wien, in June 1995.
+- **Orchestra:** Wiener Philharmoniker
+- **Choir:** Konzertvereinigung Wiener Staatsopernchor
+- **Conductor:** Myung-Whun Chung
+- **Soloists:** Luba Orgonasova, soprano; Cecilia Bartoli, mezzo-soprano; Raul Gimenez, tenor; Roberto Scandiuzzi, bass
+- **Code:** ROS-03
+
+### CD 3 — SP01: Rossini, *Stabat Mater*
+
+- **More info:** Not a commercial CD. This performance and registration originates from an initiative of some Dutch Stabat Mater enthusiasts, who later founded the Stabat Mater Foundation. Recorded at the St. Jan cathedral, ’s-Hertogenbosch, the Netherlands, in March 1997.
+- **Orchestra:** Orchestre Philharmonia de Paris
+- **Choir:** Choeur Symphonique de Paris
+- **Conductor:** Xavier Ricour
+- **Soloists:** Marie-Paule Dotti, soprano; Jaqueline Majeur, mezzo-soprano; Patrick Garayt, tenor; Christian Nadalet, bass
+- **Code:** 1998 ROS 04
+
+### CD 4 — Stichting Stabat Mater 2008 (CD 10)
+
+- **More info:** Recorded at the St. Peter church, Oirschot, the Netherlands, in March 2008 and published by the Stabat Mater Foundation.
+- **Orchestra:** Het Brabants Orkest
+- **Choir:** Brabant Koor
+- **Conductor:** Louis Buskus
+- **Soloists:** Renate Arends, soprano; Barbara Kozelj, mezzo-soprano; André Post, tenor; Martin Jan Nijhof, bass
+- **Other works:** Daan Manneke, *Stabat Mater*
+- **Code:** 2008 MAN 01
+
+### CD 5 — APR 5504 *Frederic Lamond, The complete Liszt recordings*
+
+- **More info:** Liszt frequently made transcriptions for piano from famous compositions of other composers; one was Rossini’s Stabat Mater. Mr. Decker was so kind to provide me with interesting and valuable [extra information](https://stabatmater.info/liszt-and-rossini/) and thanks to him, I could order this CD with Liszt’s piano version of *Cuius Animam Gementem*.
+- **Soloists:** Frederic Lamond, piano
+- **Other works:** 17 Liszt recordings by Frederic Lamond
+- **Code:** 2017 ROS-05
+
+## Listen
+
+<iframe allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen frameborder="0" height="253" loading="lazy" referrerpolicy="strict-origin-when-cross-origin" src="https://www.youtube.com/embed/videoseries?list=PLusFCki9uuLnTniK9hiF94Yl2tYJzDbBZ" title="Stabat Mater Foundation | 1998 - 2018" width="450"></iframe>

--- a/_composers/giovanni-battista-pergolesi.md
+++ b/_composers/giovanni-battista-pergolesi.md
@@ -1,0 +1,201 @@
+---
+title: Pergolesi, Giovanni Battista
+slug: giovanni-battista-pergolesi
+source_url: https://stabatmater.info/componist/giovanni-battista-pergolesi-2/
+---
+
+# Giovanni Pergolesi
+
+## About the composer
+
+Giovanni Battista Pergolesi (1710 – 1736) was born in Jesi, Italy. His name became known thanks to his comic opera *La Serva Padrona*. He was slightly handicapped and had a weak constitution. He probably died of tuberculosis.
+
+A lot of confusion exists about which works Pergolesi did or did not compose. As his work came more and more in demand, some publishers tried to make a little extra by taking an anonymous composition and attaching the name of Pergolesi to it. However, about the Stabat Mater there is no doubt. It is known that in his early years he composed a Stabat Mater in A minor.
+
+Probably the Stabat Mater in C minor was Pergolesi’s last composition. The commission for this work was given by the same Order in Naples for which Alessandro Scarlatti had composed a Stabat Mater in 1723. Though the score of the compositions is almost identical, the melodic lines of Pergolesi are more sentimental and highly ornamented. The piece was widely acclaimed and it seems to have inspired many composers to imitate, paraphrase and adapt (see [Brunetti](http://stabatmater.info/brunetti.html), [de Nardis](http://stabatmater.info/nardis.htm) and [Paisiello](http://stabatmater.info/paisiello.htm)). Joseph Eybler (1764 – 1846), who was a friend of Mozart and who became Court Kapellmeister in Vienna after Antonio Salieri, added a choir to replace some of the duets, and extended the orchestra. Others were John Adam Hiller/Johann Adam Hüller (1728 – 1804) and Alexy Fyodorovich L’vov (ca. 1830). The musical setting of Psalm 51 “Tilge, Höchster, meine Sünden” of the great [Johann Sebastian](http://stabatmater.info/bach.html) is another example.
+
+A completely different, and very curious adaptation is by a group called “Ophelia’s Dream” (see [CD 8](#cd-8)). It seems that this kind of music is described as “Gothic”.
+
+The Victor Alcántara Trio recorded an extended (one hour!) jazz improvisation, in which all parts of the Stabat Mater are used as starting points (see [CD 9](#cd-9)) and another interesting one is by Jazz musician Enrico Rava for string quartet, trumpet, accordion, guitar, bass and percussion (see [CD 10](#cd-10)).
+
+The well-known producer Frank Fitzpatrick, who also composed music for numerous movies, recently produced a CD in a kind of hip-hop style for the singer Sasha Lazard, with a Stabat Mater composition by him, based on Pergolesi (see [CD 11](#cd-11)).
+
+Another quite different interpretation of the first part of Pergolesi’s Stabat Mater can be found on a CD by “Le Quator” (see [CD 12](#cd-12)). This group is a string quartet, but they sing, too, playing all kinds of music, from Cole Porter to Mozart. Though they are a kind of musical clowns, their interpretation of the music comes close to being serious.
+
+The soundtrack of the George Lukas movie “THX 1138” contains a small Stabat Mater, composed by Lalo Schifrin. It starts with a line from the first part of Pergolesi’s work, but then develops into a gloomy orchestral work. It plays during the film titles (see [CD 13](#cd-13)).
+
+The first and last parts of Pergolesi’s Stabat Mater have been used in the soundtrack of the movie “Jésus de Montréal”; the third part (Quis est homo) is used in the soundtrack of the movie “Smilla’s Sense of Snow”; the last part is also used in the movie “Amadeus” and in the movie “Mirror” by Andrei Tarkovsky.
+
+The film “Cactus” by the Australian director Paul Cox is also said to have Pergolesi’s Stabat Mater on the soundtrack, but I do not know what parts are used.
+
+## About the Stabat Mater
+
+| Field | Details |
+| --- | --- |
+| **Date** | 1736 |
+| **Performers** | Soprano, alto, three violins, cello, organ |
+| **Length** | 41.44 minutes (CD 1), 41.30 minutes (CD 2), 37.27 minutes (CD 3), 40.03 minutes (CD 4), 34.58 minutes (CD 5), 39.38 minutes (CD 6), 33.12 minutes (CD 7) |
+| **Particulars** | The work is divided into twelve sections, varying from one to five stanzas. Very moving melodies, which led to some criticism because they were thought to be too cheerful. Interesting is the line "dum e-misit" which is sung intermittently, as a musical picture of the last breaths of Jesus. This is found also with some other composers.<br />Some interpretations deviate from the composer's score, as a choir has been added to the two voices (see the second colour bar, based on CD 2). This is probably based on the Eybler adaptation. |
+| **Textual variations** | The "Analecta"-version of the text is used, with one change:<br />- Stanza 16, line 2: not "Passionis eius sortem" but "Passionis fac consortem" |
+| **Colour bar** | ![Pergolesi colour bar 1](https://stabatmater.info/wp-content/uploads/colorbar/pergolesi1.gif) ![Pergolesi colour bar 2](https://stabatmater.info/wp-content/uploads/colorbar/pergolesi2.gif) |
+
+## Information about the recording
+
+### CD 1 — Decca 421 645-2: Rossini, Petite Messe Solenelle
+
+- **More info:** A double CD with Rossini’s beautiful mass, to which the Stabat Mater has been added to complete the second CD. These registrations appeared earlier on LP. The Stabat Mater was recorded at the Conservatorio di Napoli, Naples, in July 1964. It is a fine performance, with excellent soloists, though the use of a full-bodied string orchestra is not exactly as Pergolesi prescribed. I bought this CD in a record shop in the Netherlands, 1994.
+- **Orchestra:** Orchestra Rossini di Napoli
+- **Conductor:** Franco Carraciolo
+- **Soloists:** Judith Raskin, soprano; Maureen Lehane, alto
+- **Other works:** Gioacchino Rossini: *Petite Messe Solennelle*
+- **Code:** 1994 ROS 02
+
+### CD 2 — Decca 443 869-2 (double CD): Pergolesi/Scarlatti/Bononcini – Stabat Mater
+
+- **More info:** A nice collection of Stabat Maters and some other works, even if the registrations are rather old. As it is the only Bononcini registration that I know of, every collector should have it. Pergolesi was recorded in 1978. The performance deviates from the original score, as a choir is used in some sections, and, of course, a full-bodied string orchestra. I bought this CD in a record shop in the Netherlands, 1997.
+- **Orchestra:** The Argo Chamber Orchestra
+- **Choir:** Choir of St. John’s College, Cambridge
+- **Conductor:** George Guest
+- **Soloists:** Felicity Palmer, soprano; Alfreda Hodgson, alto
+- **Other works:** Giovanni Battista Pergolesi, *Magnificat* in C major; Antonio Bononcini, *Stabat Mater*; Domenico Scarlatti, *Stabat Mater*; Alessandro Scarlatti, *O magnum mysterium* + *Domine, refugium factus est nobis*; Antonio Lotti, *Crucifixus*
+- **Code:** 1997 BON 01
+
+### CD 3 — L’Oiseau-Lyre 425 692-2: Pergolesi – Stabat Mater – Salve Regina
+
+- **More info:** Recorded at the St Jude’s Church, London, in August 1988. Another fine performance, with excellent soloists, though again the use of a full-bodied string orchestra is not exactly as Pergolesi prescribed. Some people find this interpretation too florid.
+- **Orchestra:** Academy of Ancient Music
+- **Conductor:** Christopher Hogwood
+- **Soloists:** Emma Kirkby, soprano; James Bowman, countertenor
+- **Other works:** Giovanni Battista Pergolesi: *Salve Regina*
+- **Code:** PER 01
+
+### CD 4 — STH Quality Records 19343: Giovanni Pergolesi, Stabat Mater
+
+- **More info:** I like this one, even if I am not very fond of trebles, because the interpretation is as close to the original as possible. No female singers are used, and the accompaniment is as Pergolesi wrote. Pure Pergolesi! Recorded at the St. Joriskerk, Amersfoort, Netherlands, in May 1993.
+- **Orchestra:** Florilegium Musicum
+- **Conductor:** Pieter Jan Leusink
+- **Soloists:** Martinus Leusink, treble; Sytze Buwalda, countertenor
+- **Code:** Unknown PER 02
+
+### CD 5 — Alpha 009: Musica napoletana per la festa della Vergine dei Sette dolori
+
+- **More info:** This CD tries to paint a picture of the festivities that took place in the streets of Naples in the 18th century during processions held in honor of the Virgin of the Seven Sorrows, on the Friday before Palm Sunday. Recorded in Paris, February 2000. The Pergolesi Stabat Mater is performed with a light accompaniment, as it should, but stanzas 1, 3, 10 and 20 are sung not by soloists, but by a choir. It is a very fast interpretation.
+- **Orchestra:** Le Poème Harmonique
+- **Choir:** Les Pages et les Chantres de la Chapelle
+- **Conductor:** Olivier Schneebell
+- **Soloists:** Arno Meier, Florent Msigtot, Marie Planinsek (trebles); Damien Guillon, Bruno Le Levreur (countertenor)
+- **Other works:** Anonymous: *Stabat Mater* intonation; Anonymous: *Tarantella*; Anonymous: *Stabat Mater à trois voix*; Francesco Durante: Concerto nr 4 en mi
+- **Code:** Unknown (PER 03)
+
+### CD 6 — Novità della Classica: Pergolesi, Stabat Mater – Salve Regina – In Coelestibus Regnis
+
+- **More info:** Nice performance, with fine soloists, but again, with the use of a full-bodied string orchestra. Recorded at the Sacrestia Monumentale della Chiesa di San Marco, Milan, in February 1996.
+- **Orchestra:** I Solisti dell'Orchestra Filarmonica della Scala
+- **Conductor:** Ricardo Muti
+- **Soloists:** Barbara Frittoli, soprano; Anna Caterina Antonacci, alto
+- **Other works:** *Salve Regina*; *In Coelestibus Regnis*
+- **Code:** PER 04
+
+### CD 7 — KRO ES47.387: Stabat Mater Giovanni Pergolesi
+
+- **More info:** This CD is produced by the Dutch KRO radio, in cooperation with the Stabat Mater Foundation. Even faster than CD 5. Yet again, with the use of a full-bodied string orchestra. Also, the soloists are partly—during six stanzas—replaced by a female choir. Nevertheless, a performance worth listening to, in a suitable location. Moreover, it features the world premiere of the Stabat Mater by Fiocco. It is a recording of a concert performed on April 1, 2001 in the St. Petrus church at Oirschot.
+- **Choir:** Capella Brugensis
+- **Conductor:** Patrick Peire
+- **Soloists:** Roberta Alexander, soprano; Sytse Buwalda, alto
+- **Other works:** Pietro Antonio Fiocco, *Stabat Mater*; Giovanni Pierluigi da Palestrina, *Stabat Mater*
+- **Code:** 2001 (FIO 01)
+
+### CD 8 — Sad Eyes (Trinity Records) TRI 051 CD: Ophelia’s Dream – Stabat Mater – EP {#cd-8}
+
+- **More info:** It is a pity that very little information is given with this CD. A sticker on the box tells us: “*Heavenly voices & neo-classic with a feeling of an honest, eyeball-to-eyeball confrontation with Death, or laughter in the face of Death. Goth in its purest and darkest sense!*” I would describe it as an extremely romantic, heavily accentuated adaption of the Pergolesi work. Nevertheless, I like it! The normal string orchestra has been extended by clavichord, piano and church organ. Stanzas 2 and 4 are played as orchestral interludes, while stanza 10 is a toccata-like organ solo. The final Amen is played as a piano solo. Stanzas 9 and 11 through 19 are omitted. Recorded in the Nova Tonstudio Beilstein; no date is given. The total playing time is only 23.43 minutes! I bought this CD on the Internet, Martz-Mailorder, 2001.
+- **Soloists:** Susanne Stierle and Dietmar Greulich (probably the two singers, soprano and alto)
+- **Code:** 2001 PER 05
+
+### CD 9 — Organic Music ORGM 9716: Victor Alcántara Trio. Stabat Mater Inspirations {#cd-9}
+
+- **More info:** A very nice improvisation. As Victor Alcántara writes: “This trio arrangement is intended to let the music speak for itself. The text was not the point of departure for the arrangement, though it has left its mark. I hope that despite the musical treatment to which the original has been subjected, the listener can still perceive the love which with Pergolesi wrote his work an which remains immanent in it”. Recorded in Germany in 1999.
+- **Orchestra:** Victor Alcántara Trio
+- **Soloists:** Victor Alcántara, piano; Thomas Stabenow, bass; Bastian Jütte, percussion
+- **Code:** PER 06
+
+### CD 10 — Harmonia Mundi (Label Bleu) LBLC 6559: “Rava l’opera va” {#cd-10}
+
+- **More info:** Partly, the jazz improvisation follows the Pergolesi melodies in a very relaxed way, partly it consists of Miles Davis-like improvisations, not really my taste. The CD was recorded in Italy in 1993. I bought this CD in a record shop in the Netherlands in 1999.
+- **Orchestra:** String quartet "Insieme strumentale di Roma"
+- **Soloists:** Enrico Rava, trumpet; Richard Galliano, accordion; Battista Lena, guitar; Palle Danielsson, bass; Jon Christensen, percussion
+- **Other works:** Jazz improvisations on works by Puccini (a.o. *Tosca*) and Bizet
+- **Code:** 1999 PER 07
+
+### CD 11 — Omtown OMCD 11552: Sasha Lazard, *The Myth of Red* {#cd-11}
+
+- **More info:** A collection of songs, described on Sasha Lazard’s website as: Operatic arias fused together with primal/tribal electronic hip-hop beats. We can hear Pergolesi in the song “Stabat Mater IXXI” and in “Stabat Mater Reprise”. Recorded in the USA in 2002. I bought this CD on the Internet, JPC.de, 2003.
+- **Orchestra:** Keyboards, synth bass, percussion, cello
+- **Soloists:** Sasha Lazard, soprano
+- **Other works:** The music is partly based on classical music (for instance Rachmaninov, Caccini, Verdi, Cesti, Saint-Saëns)
+- **Code:** 2003 PER 08
+
+### CD 12 — JMS 18689-2: Le Quator {#cd-12}
+
+- **More info:** A collection of musical pieces which resemble patchwork, being composed of parts of classical music, modern and traditional songs, played by musical clowns. Still, it is quite nice to listen to. Pity that I cannot understand what they sing. I bought this CD on the Internet, JPC.de, 2003.
+- **Orchestra:** Le Quator, consisting of Jean-Claude Camors (violin), Laurent Vercambre (violin), Pierre Ganem (viola), Laurent Cirade (cello)
+- **Other works:** In the twelve pieces on the CD we can hear shards of Mozart, Borodin, Brahms, Tchaikovsky and others.
+- **Code:** 2003 PER 09
+
+### CD 13 — Film Score Monthly, Vol. 6, Nr. 4 – Lalo Schifrin, *THX 1138* {#cd-13}
+
+- **More info:** The original motion picture soundtrack of *THX 1138*, an SF movie by George Lukas, made in 1969. I bought this CD on the Internet, Buysoundtrax.com, 2004.
+- **Orchestra:** Unknown, but conducted by Lalo Schifrin
+- **Code:** 2004 PER 10
+
+### CD 14 — Live recording, Saxo Panico (March 27, 2008, Bethaniënklooster, Amsterdam)
+
+- **More info:** This is a very special performance. Saxo Panico is a saxophone quartet. They made an arrangement of the Pergolesi Stabat Mater for their saxophone quartet. Apart from a few minimal adaptations, they remain totally true to the original composition by Pergolesi. I visited the concert and they gave me a CD. You can listen to it [here](https://www.youtube.com/watch?v=i783jrnALnQ).
+- **Orchestra:** Saxo Panico
+- **Soloists:** Mariëtte Oelderik, soprano; Marianne Selliger, alto
+- **Code:** January 2009 – PER 11
+
+### CD 15 — *Looking Back over the Baroque* – Andreas Prittwitz
+
+- **More info:** The CD contains baroque music (Pergolesi, Bach, Corelli, Vivaldi, Purcell) with original instruments, mixed with modern instruments and improvisations. Sometimes a bit jazzy, sometimes romantic. I like it very much. Andreas Prittwitz sent the CD (and another one *Looking Back over the Renaissance*) to me because of Pergolesi’s *Stabat Mater Dolorosa* (only the first stanza). On YouTube you can watch the [video about Pergolesi’s Stabat Mater](https://www.youtube.com/watch?v=5fqmEu5ULls&feature=channel).
+- **Orchestra:** The musicians are Andreas Prittwitz (soprano saxophone and clarinet), Krzysztof Wisniewsky and Joan Espina (violins), Christina Pozas (viola), Miguel Jiménez (violoncello), Roberto Terrón (contrabas)
+- **Other works:** J. S. Bach, Preludio (Suite Nº1 for Violoncello); A. Corelli, *La Follia*; J. S. Bach, *Siciliano* (Sonata Nº2 for Flute); A. Vivaldi, *Largo* (Concerto en Do per Ottavino); Casper Sanz, *Lantururú – Zarabanda - Canarios*; Henry Purcell, Aria 37 (*Dido & Aeneas*); J. S. Bach, *Minueto I & II* (Suite Nº1 for Violoncello) – Suite Nº1 for Violoncello (adapted for recorder)
+- **Code:** October 2010 PER 12
+
+### CD 16 — GLO 5245 *Smart had moeders hart bevangen* (NPU)
+
+- **More info:** This Pergolesi Stabat Mater is sung in Dutch. The translation is from Willem Wilmink.
+- **Orchestra:** De Nieuwe Philharmonie Utrecht
+- **Conductor:** Johannes Leertouwer
+- **Soloists:** Klaartje van Veldhoven, soprano; Rob Meijers, alto; Marten Root, traverso
+- **Other works:** Wilhelm Friedeman Bach: *Adagio & Fuga* in d-minor; Antonio Vivaldi: *Sinfonia al Santosepolcro* in b-minor; Frantsek Benda: Concerto for flute and strings
+- **Code:** 2012 PER-13
+
+### CD 17 — Stabat Mater Foundation 2013: Pergolesi (Tawfic, Despresz)
+
+- **More info:** The recording of the 15th concert organised by the Dutch Stabat Mater Foundation. Recorded at the Sint Petrus Church, Oirschot, in March 2013.
+- **Orchestra:** Euterpe Baroque Consort
+- **Conductor:** Stratton Bull
+- **Soloists:** Ilse Eerens, soprano; Mirjam Schreur, alto
+- **Other works:** Josquin Despresz, *Stabat Mater*; Giovanni Battista Pergolesi, *Stabat Mater*
+- **Code:** 2015 TAW-01
+
+### CD 18 — *Pergolesi Stabat Mater* HMA 1951119
+
+- **More info:** This CD was released in 2011 but the recording is from 1981. I own the CD for a long time and I don’t know why I did not add it before. I am sorry, I don’t remember how I did get it. But I listened to it now and I like it very much, especially the voice of René Jacobs. Listen [here](https://www.youtube.com/watch?v=x8WRyrBQLsM) to the complete recording.
+- **Orchestra:** Concerto Vocale
+- **Conductor:** René Jacobs
+- **Soloists:** Sebastian Hennig, soprano; René Jacobs, countertenor
+- **Code:** PER 14
+
+### CD 19 — CPO 555 103-2 *Pergolesi, Stabat Mater* — Marie-Luise Hinrichs
+
+- **More info:** This CD was sent to me by Orlando Romulo Sanchez. He is the manager of the concert pianist Marie-Luise Hinrichs. She made the transcription for piano solo of Pergolesi’s Stabat Mater herself. Thank you very much!
+- **Orchestra:** Marie-Luise Hinrichs
+- **Other works:** Domenico Scarlatti, Sonata in B flat major; Sonata in D minor; Sonata in D minor; Sonata in C major; Sonata in E major
+- **Code:** PER15 (2018)
+
+## Listen
+
+<iframe allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen frameborder="0" height="253" loading="lazy" referrerpolicy="strict-origin-when-cross-origin" src="https://www.youtube.com/embed/videoseries?list=PLusFCki9uuLml6ZJgmDIwS3bA2895pyem" title="Stabat Mater - Pergolesi" width="450"></iframe>
+
+<iframe allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen frameborder="0" height="253" loading="lazy" referrerpolicy="strict-origin-when-cross-origin" src="https://www.youtube.com/embed/a4XBYXWps7g?feature=oembed" title="Stabat Mater - Pergolesi cd 8" width="450"></iframe>

--- a/_composers/joseph-haydn.md
+++ b/_composers/joseph-haydn.md
@@ -1,0 +1,51 @@
+---
+title: Haydn, Joseph
+slug: joseph-haydn
+source_url: https://stabatmater.info/componist/joseph-haydn/
+---
+
+# Franz Joseph Haydn
+
+## About the composer
+
+Joseph Haydn (1732 – 1809) was born in Rohrau, Austria. He composed amongst others more than 100 symphonies, 84 string quartets, 10 masses and four large oratorios. His Stabat Mater was praised by his contemporaries, for instance by the then famous composer Hasse.
+
+Haydn, who had sent it to Hasse in the hope that “this great and world-celebrated composer” (Haydn’s words) would rectify the weaker parts of the composition, was completely surprised that Hasse “honoured the work by inexpressibly praise”.
+
+Even during his life it was published on a large scale and became his most well-known sacred work. Haydn died in Vienna.
+
+## About the Stabat Mater
+
+| Field | Details |
+| --- | --- |
+| **Date** | 1767 |
+| **Performers** | Soprano, tenor, alto, bass, choir and orchestra |
+| **Length** | 69.01 minutes |
+| **Particulars** | The work is divided into 13 sections. The work is built round five choruses, seven arias and one duet. In the final movement the chorus establishes the vision of the Paradise in a bright G major, a fugue that becomes more and more florid until it encourages a burst of grateful coloratura from the soprano. |
+| **Textual variations** | The "Analecta"-text is used, with following changes:<br />- Stanza 14, line 2: not "Te libenter sociare" but "Et me tibi sociare"<br />- Stanza 16, line 2: not "Passionis eius sortem" but "Passionis fac consortem"<br />- Stanza 18, lines 1 and 2: not "Inflammatus et accensus, per Te, Virgo, sim defensus" but "Flammis orci ne succendar, per Te, Virgo, fac, defendar" |
+| **Colour bar** | ![Colour bar for Joseph Haydn](https://stabatmater.info/wp-content/uploads/colorbar/haydn.gif) |
+
+## Information about the recording
+
+### CD 1 — Deutsche Grammophon 429 733-2: Joseph Haydn, *Stabat Mater*
+
+- **More info:** The work was played on authentic instruments and recorded at the All Saints’ Church, London, in July 1989. You can listen to this recording (see “Listen” on this webpage).
+- **Orchestra:** The English Consort
+- **Choir:** The English Consort Choir
+- **Conductor:** Trevor Pinnock
+- **Soloists:** Patricia Rozario, soprano; Catherine Robbin, mezzo-soprano; Anthony Rolfe Johnson, tenor; Cornelius Hauptmann, bass
+- **Code:** 1994 HAY 01
+
+### CD 2 — *Twee Stabat Maters uit Wenen*: Draghi en Haydn
+
+- **More info:** The recording of the 16th concert organized by the Dutch Stabat Mater Foundation. Recorded at the St. Petrus church, Oirschot, in March 2014.
+- **Orchestra:** Brabant Philharmonie Zuid Nederland
+- **Choir:** Brabant Koor Zuid Nederland
+- **Conductor:** Kazem Abdullah
+- **Soloists:** Annelies van Gramberen, soprano; Carina Vinke, alt; Falco van Loon, tenor; Bert van de Wetering, bas
+- **Other works:** Antonio Draghi, *Stabat Mater*
+- **Code:** 2014 DRA-01 (252)
+
+## Listen
+
+<iframe allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen frameborder="0" height="253" loading="lazy" referrerpolicy="strict-origin-when-cross-origin" src="https://www.youtube.com/embed/A5sAqvoOt_I?feature=oembed" title="Stabat Mater Foundation - Franz Joseph Haydn (2014)" width="450"></iframe>

--- a/_config.yml
+++ b/_config.yml
@@ -10,6 +10,9 @@ permalink: pretty
 collections:
   posts:
     output: true
+  composers:
+    output: true
+    permalink: /composers/:slug/
 sass:
   sass_dir: assets/css
   style: compressed

--- a/composers/index.md
+++ b/composers/index.md
@@ -1,0 +1,13 @@
+---
+title: Composers
+permalink: /composers/
+---
+
+<ul class="composer-list">
+  {% assign sorted = site.composers | sort: 'title' %}
+  {% for composer in sorted %}
+    <li>
+      <a href="{{ composer.url | relative_url }}">{{ composer.title }}</a>
+    </li>
+  {% endfor %}
+</ul>


### PR DESCRIPTION
## Summary
- convert the initial composer profile pages from raw HTML payloads into structured Markdown content
- retain the original narrative details, tables, and discography information using Markdown tables, headings, and lists for clarity

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da922a271883338c32a1651f7dad4a