### PR TITLE
Update composer navigation URLs

### DIFF
--- a/_includes/secondary-nav.html
+++ b/_includes/secondary-nav.html
@@ -4,12 +4,12 @@
       <a href="{{ '/' | relative_url }}" aria-current="page">Home</a>
     </li>
     <li class="menu-item menu-item-has-children">
-      <a href="{{ '/stabat-mater-composer/' | relative_url }}">Composers</a>
+      <a href="{{ '/composers/' | relative_url }}">Composers</a>
       <ul class="sub-menu">
-        <li class="menu-item"><a href="{{ '/stabat-mater-composer/alphabetically/' | relative_url }}">Alphabetically</a></li>
-        <li class="menu-item"><a href="{{ '/stabat-mater-composer/countries-of-origin/' | relative_url }}">By country of origin</a></li>
-        <li class="menu-item"><a href="{{ '/stabat-mater-composer/chronologically/' | relative_url }}">Chronologically</a></li>
-        <li class="menu-item"><a href="{{ '/stabat-mater-composer/duration/' | relative_url }}">By duration</a></li>
+        <li class="menu-item"><a href="{{ '/composers/alphabetically/' | relative_url }}">Alphabetically</a></li>
+        <li class="menu-item"><a href="{{ '/composers/countries-of-origin/' | relative_url }}">By country of origin</a></li>
+        <li class="menu-item"><a href="{{ '/composers/chronologically/' | relative_url }}">Chronologically</a></li>
+        <li class="menu-item"><a href="{{ '/composers/duration/' | relative_url }}">By duration</a></li>
       </ul>
     </li>
     <li class="menu-item"><a href="{{ '/stabat-mater-dolorosa-about-the-poem/' | relative_url }}">Texts</a></li>

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -38,10 +38,10 @@
     <div class="textwidget">
       <p>
         Search for composers:<br />
-        <a href="{{ '/composer/alphabetically/' | relative_url }}">Alphabetically</a><br />
-        <a href="{{ '/composer/countries-of-origin/' | relative_url }}">By countries of origin</a><br />
-        <a href="{{ '/composer/chronologically/' | relative_url }}">Chronologically</a><br />
-        <a href="{{ '/composer/duration/' | relative_url }}">By duration</a>
+        <a href="{{ '/composers/alphabetically/' | relative_url }}">Alphabetically</a><br />
+        <a href="{{ '/composers/countries-of-origin/' | relative_url }}">By countries of origin</a><br />
+        <a href="{{ '/composers/chronologically/' | relative_url }}">Chronologically</a><br />
+        <a href="{{ '/composers/duration/' | relative_url }}">By duration</a>
       </p>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- update the secondary navigation composer links to use the /composers/ URL structure
- mirror the updated composer URLs in the sidebar widgets

## Testing
- bundle exec jekyll build

------
https://chatgpt.com/codex/tasks/task_e_68dac55854088333b6530949064ef48b