### PR TITLE
Adjust composer tables to prevent wrapped field names

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -431,6 +431,22 @@ a:hover {
   margin: 32px 0 12px;
 }
 
+.entry-content table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.entry-content table th,
+.entry-content table td {
+  padding: 8px 12px;
+}
+
+.entry-content table th:first-child,
+.entry-content table td:first-child {
+  min-width: 220px;
+  white-space: nowrap;
+}
+
 .wp-block-embed {
   background: #f8f8f8;
   border: 1px solid #e0e0e0;


### PR DESCRIPTION
## Summary
- ensure composer detail tables span the full width of the content
- set a minimum width and no-wrap behavior on the first column so field labels stay on one line

## Testing
- bundle exec jekyll serve --host 0.0.0.0 --port 4000

------
https://chatgpt.com/codex/tasks/task_e_68e685d15ecc8333b86d48ff500573a0